### PR TITLE
Add missing linearity checks to CIVL

### DIFF
--- a/Source/Core/BoogiePL.atg
+++ b/Source/Core/BoogiePL.atg
@@ -63,17 +63,18 @@ public static int Parse (string s, string/*!*/ filename, out /*maybe null*/ Prog
 
   Parser parser = new Parser(scanner, errors, false);
   parser.Parse();
-  if (parser.errors.count == 0)
+  if (errors.count == 0)
+  {
+    parser.Pgm.ProcessDatatypeConstructors(errors);
+  }
+  if (errors.count == 0)
   {
     program = parser.Pgm;
-    program.ProcessDatatypeConstructors();
-    return 0;
-  }
-  else
+  } else
   {
     program = null;
-    return parser.errors.count;
   }
+  return errors.count;
 }
 
 public Parser(Scanner/*!*/ scanner, Errors/*!*/ errors, bool disambiguation)

--- a/Source/Provers/SMTLib/ProverInterface.cs
+++ b/Source/Provers/SMTLib/ProverInterface.cs
@@ -1712,7 +1712,7 @@ namespace Microsoft.Boogie.SMTLib
             }
 
             if (SortSet.ContainsKey(type.Name) && SortSet[type.Name] == 0) {
-                var prefix = "@uc_T_" + type.Name.Substring(2) + "_";
+                var prefix = "@uc_T@" + type.Name.Substring(2) + "_";
                 if (element.Name.StartsWith(prefix)) {
                     m.Append(type.Name + "!val!" + element.Name.Substring(prefix.Length));
                     return;
@@ -1746,10 +1746,13 @@ namespace Microsoft.Boogie.SMTLib
                 ConstructFunctionArguments(arguments[0], argTypes, argValues);
                 ConstructFunctionArguments(arguments[1], argTypes, argValues);
             } else if (arguments.Name == "=" &&
-                       (arguments[0].Name.StartsWith("_ufmt_") || arguments[0].Name.StartsWith("x!"))) {
+                       (arguments[0].Name.StartsWith("_ufmt_") || arguments[0].Name.StartsWith("x!") ||
+	                arguments[0].Name.StartsWith("_arg_"))) {
                 int argNum;
                 if (arguments[0].Name.StartsWith("_ufmt_"))
                     argNum = System.Convert.ToInt32(arguments[0].Name.Substring("_uftm_".Length)) - 1;
+                else if (arguments[0].Name.StartsWith("_arg_"))
+		    argNum = System.Convert.ToInt32(arguments[0].Name.Substring("_arg_".Length)) - 1;
                 else /* if (arguments[0].Name.StartsWith("x!")) */
                     argNum = System.Convert.ToInt32(arguments[0].Name.Substring("x!".Length)) - 1;
                 if (argNum < 0 || argNum >= argTypes.Count) {
@@ -1790,7 +1793,7 @@ namespace Microsoft.Boogie.SMTLib
 
             for (int i = 0; i < inType.ArgCount; ++i) {
                 if (inType[i].Name != "_ufmt_" + (i + 1) && inType[i].Name != "x!" + (i + 1) &&
-                    !inType[i].Name.StartsWith("BOUND_VARIABLE_")) {
+                    !inType[i].Name.StartsWith("BOUND_VARIABLE_") && inType[i].Name != "_arg_" + (i + 1)) {
                     Parent.HandleProverError("Unexpected function argument: " + inType[i].Name);
                     throw new BadExprFromProver ();
                 }
@@ -1850,7 +1853,7 @@ namespace Microsoft.Boogie.SMTLib
                 dt.Types.Add(typeDef[0][i][0]);
             }
 
-            DataTypes[typeDef.Name] = dt;
+            DataTypes[datatypes[0][0].Name] = dt;
         }
 
         private void ConvertErrorModel(StringBuilder m) {


### PR DESCRIPTION
For all atomic actions, it is checked that the outgoing linear values are a subset of the incoming linear values.
Tests are updated accordingly.
Missing linear collector is now a type checking error.